### PR TITLE
Migrate databroker handlers

### DIFF
--- a/startup/20-area-detectors.py
+++ b/startup/20-area-detectors.py
@@ -8,7 +8,6 @@ from ophyd.areadetector.filestore_mixins import (FileStoreBase, new_short_uid)
 from ophyd import Component as Cpt, Signal
 from ophyd.utils import set_and_wait
 from pathlib import PurePath
-from eiger_io.fs_handler_dask import EigerHandlerDask
 
 
 class EigerSimulatedFilePlugin(Device, FileStoreBase):
@@ -139,6 +138,4 @@ eiger1m_single = EigerSingleTrigger('XF:04IDD-ES{Det:Eig1M}',
                                     name='eiger1m_single')
 
 set_eiger_defaults(eiger1m_single)
-
-db.reg.register_handler('AD_EIGER2', EigerHandlerDask, overwrite=True)
 


### PR DESCRIPTION
Databroker handlers will be migrated to dedicated repositories as part of April deployment.

Related: https://github.com/bluesky/databroker/issues/533

Eiger-io handlers will now be provided by [area-detector-handlers](https://github.com/bluesky/area-detector-handlers).